### PR TITLE
feat: use new wordpress order when making requests

### DIFF
--- a/src/nettle-pay.php
+++ b/src/nettle-pay.php
@@ -238,14 +238,17 @@ function nettle_pay_init() {
                 self::log('[INFO] process_payment(): got currency response: ' . print_r($response, true));
 
                 $requestParams = array(
-                    "callbackUrl" => get_bloginfo('url') . '/?wc-api=nettle_pay_webhook&nonce=' . $nonce . '&order_id=' . $order_id,
                     "cancelUrl" => $this->get_cancel_url($order),
                     "payment" => array(
                         "atomicAmount" => $order->get_total() * pow(10, $response['decimal']),
                         "baseCurrencyCode" => $response['code'],
                     ),
-                    "externalId" => (string) $order_id,
                     "successUrl" => $this->get_return_url($order),
+                    "wordPressOrder" => array(
+                        "nonce" => (string) $nonce,
+                        "webhookUrl" => get_bloginfo('url'),
+                        "wpOrderId" => (string) $order_id,
+                    ),
                 );
 
                 self::log('[INFO] process_payment(): attempting to generate payment for order id "' . $order_id . '"...');

--- a/src/nettle-pay.php
+++ b/src/nettle-pay.php
@@ -220,7 +220,7 @@ function nettle_pay_init() {
                 }
 
                 // create a nonce to use on the callback url
-                $nonce = substr(str_shuffle(md5(microtime())), 0, 12);
+                $nonce = substr(str_shuffle(md5(microtime())), 0, 32);
 
                 wc_add_order_item_meta($order_id, 'ipn_nonce', $nonce);
 


### PR DESCRIPTION
<!--
The title should summarise what the purpose of this change,

⚠️**NOTE:** The title must conform to the conventional commit message format outlined in CONTRIBUTING.md document, at the root of the project. This is to ensure the merge commit to the main branch is picked up by the CI and creates an entry in the CHANGELOG.md.
-->

# Description
<!-- Describe your changes in detail -->
* Use the new WordPress order object when sending checkout creation requests

# Type of change
<!-- What type of change does this change introduce? Put an 'x' in all the boxes that apply. -->

- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🏗️ Build configuration (CI configuration, scaffolding etc.)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 📝 Documentation update
- [ ] 📦 Dependency updates
- [ ] 👩🏽‍💻 Improve developer experience
- [ ] ⚡ Improve performance
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] ♻ Refactor
- [ ] ⏪️ Revert changes
- [ ] 🔧 Task (a small and general change)
